### PR TITLE
Bug fix - indentation after options and parallel calls in MscGen

### DIFF
--- a/render/text/ast2mscgen.js
+++ b/render/text/ast2mscgen.js
@@ -19,16 +19,13 @@ define(["./arcmappings", "./textutensils", "./ast2thing"], function(map, utl, th
     var INDENT = "  ";
     var SP = " ";
     var EOL = "\n";
-    var gMinimal = false;
 
     function init(pMinimal) {
         if (true === pMinimal) {
-            gMinimal = true;
             INDENT = "";
             SP = "";
             EOL = "";
         } else {
-            gMinimal = false;
             INDENT = "  ";
             SP = " ";
             EOL = "\n";
@@ -65,7 +62,7 @@ define(["./arcmappings", "./textutensils", "./ast2thing"], function(map, utl, th
                 },
                 "option" : {
                     "opener" : INDENT,
-                    "separator" : "," + EOL,
+                    "separator" : "," + EOL + INDENT,
                     "closer" : ";" + EOL + EOL
                 },
                 "entity" : {
@@ -81,7 +78,7 @@ define(["./arcmappings", "./textutensils", "./ast2thing"], function(map, utl, th
                 },
                 "arcline" : {
                     "opener" : INDENT,
-                    "separator" : "," + EOL,
+                    "separator" : "," + EOL + INDENT,
                     "closer" : ";" + EOL
                 },
                 "inline" : {

--- a/test/render/text/t_ast2mscgen.js
+++ b/test/render/text/t_ast2mscgen.js
@@ -37,6 +37,16 @@ describe('render/text/ast2mscgen', function() {
             var lExpectedProgram = "msc {\n  Alice [linecolor=\"#008800\", textcolor=\"black\", textbgcolor=\"#CCFFCC\", arclinecolor=\"#008800\", arctextcolor=\"#008800\"],\n  Bob [linecolor=\"#FF0000\", textcolor=\"black\", textbgcolor=\"#FFCCCC\", arclinecolor=\"#FF0000\", arctextcolor=\"#FF0000\"],\n  pocket [linecolor=\"#0000FF\", textcolor=\"black\", textbgcolor=\"#CCCCFF\", arclinecolor=\"#0000FF\", arctextcolor=\"#0000FF\"];\n\n  Alice => Bob [label=\"do something funny\"];\n  Bob => pocket [label=\"fetch (nose flute)\", textcolor=\"yellow\", textbgcolor=\"green\", arcskip=\"0.5\"];\n  Bob >> Alice [label=\"PHEEE!\", textcolor=\"green\", textbgcolor=\"yellow\", arcskip=\"0.3\"];\n  Alice => Alice [label=\"hihihi\", linecolor=\"#654321\"];\n}";
             assert.equal(lProgram, lExpectedProgram);
         });
+        it("correctly renders multiple options", function() {
+            var lProgram = renderer.render(fix.astOptionsMscgen);
+            var lExpectedProgram = 'msc {\n  hscale="1.2",\n  width="800",\n  arcgradient="17",\n  wordwraparcs="true";\n\n  a;\n\n}';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+        it("correctly renders parallel calls", function() {
+            var lProgram = renderer.render(fix.astSimpleParallel);
+            var lExpectedProgram = 'msc {\n  a,\n  b,\n  c;\n\n  b -> a [label="{paral"],\n  b =>> c [label="lel}"];\n}';
+            assert.equal(lProgram, lExpectedProgram);
+        });
     });
 
     describe('#renderAST() - minification', function() {

--- a/test/render/text/t_ast2msgenny.js
+++ b/test/render/text/t_ast2msgenny.js
@@ -1,8 +1,8 @@
-var assert = require("assert");
+var assert   = require("assert");
 var renderer = require("../../../render/text/ast2msgenny");
-var fix = require("../../astfixtures");
-var utl = require("../../testutensils");
-var path = require('path');
+var fix      = require("../../astfixtures");
+var utl      = require("../../testutensils");
+var path     = require('path');
 
 describe('render/text/ast2msgenny', function() {
     describe('#renderAST() - mscgen classic compatible - simple syntax trees', function() {

--- a/test/render/text/t_ast2xu.js
+++ b/test/render/text/t_ast2xu.js
@@ -38,6 +38,18 @@ describe('render/text/ast2xu', function() {
             assert.equal(lProgram, lExpectedProgram);
         });
 
+        it("correctly renders multiple options", function() {
+            var lProgram = renderer.render(fix.astOptionsMscgen);
+            var lExpectedProgram = 'msc {\n  hscale="1.2",\n  width="800",\n  arcgradient="17",\n  wordwraparcs="true";\n\n  a;\n\n}';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+
+        it("correctly renders parallel calls", function() {
+            var lProgram = renderer.render(fix.astSimpleParallel);
+            var lExpectedProgram = 'msc {\n  a,\n  b,\n  c;\n\n  b -> a [label="{paral"],\n  b =>> c [label="lel}"];\n}';
+            assert.equal(lProgram, lExpectedProgram);
+        });
+
     });
 
     describe('#renderAST() - minification', function() {


### PR DESCRIPTION
- fixes a bug in ast2mscgen where next lines in option lists and arc lines weren't indented
- adds unit tests to ensure this doesn't happen in ast2xu
- (ast2msgenny already had tests for this in place)
